### PR TITLE
bugfix transpose on avec and bvec in w90 call

### DIFF
--- a/src/genw90input.f90
+++ b/src/genw90input.f90
@@ -97,8 +97,8 @@ if ( nspinor .eq. 2 ) then
 end if
 
 ! call wannier90 library
-call wannier_setup(trim(wann_seedname),ngridk,nkpt,bohr2angstrom*avec,&   !in
-                   (1/bohr2angstrom)*bvec,vkl,nstsv,natmtot,&             !in
+call wannier_setup(trim(wann_seedname),ngridk,nkpt,bohr2angstrom*transpose(avec),&   !in
+                   (1/bohr2angstrom)*transpose(bvec),vkl,nstsv,natmtot,&             !in
                    wann_atomsymb,wann_atompos,.false.,spinors_lib,&       !in
                    wann_nntot,nnlist,nncell,wann_nband_total,wann_nwf,&   !out
                    wann_proj_site,wann_proj_l,wann_proj_m,&               !out


### PR DESCRIPTION
Dear Arsenii,

I have been able to get your wannier90 wrapper working for my system. But in doing so I discovered a small bug in the passing of the unit cell and reciprocal unit cell vectors in the library call to wannier90 in `genw90input.f90`. There was a transpose missing on both of them.

Here is a pull request with a bugfix, please consider merging it.

Thank you for the help!

Cheers, Hugo